### PR TITLE
Fixes to Packer

### DIFF
--- a/code/packer/ubuntu1804-aws/packer.pkr.hcl
+++ b/code/packer/ubuntu1804-aws/packer.pkr.hcl
@@ -57,7 +57,7 @@ build {
   sources = ["source.amazon-ebs.ubuntu1804"]
 
   provisioner "ansible" {
-    extra_arguments = ["-vvvv"]
+    # extra_arguments = ["-vvvv"]
     playbook_file   = "./playbook.yml"
   }
 }

--- a/code/packer/ubuntu1804-aws/packer.pkr.hcl
+++ b/code/packer/ubuntu1804-aws/packer.pkr.hcl
@@ -59,5 +59,6 @@ build {
   provisioner "ansible" {
     # extra_arguments = ["-vvvv"]
     playbook_file   = "./playbook.yml"
+    user            = "ubuntu"
   }
 }

--- a/code/packer/ubuntu1804-aws/playbook.yml
+++ b/code/packer/ubuntu1804-aws/playbook.yml
@@ -10,7 +10,7 @@
       shell: export LANG=en_US.UTF-8
 
     - name: Install third party repositories
-      apt_repository: repo='{{ item }}' update_cache=yes
+      apt_repository: repo='{{ item }}'
       with_items:
         - ppa:certbot/certbot
         - ppa:brightbox/ruby-ng # AWS and/or Canonical's release breaks from time to time


### PR DESCRIPTION
During provisioning of an AWS AMI over Gitlab CI. After encountering several errors with Packer/Ansible, I found out that it would be logged in as `root` instead of `ubuntu` during the provisioning process. Found a reference to the error indicated in commit 6f644a1.